### PR TITLE
add homepage and repo in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwind-react-native-classnames",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwind-react-native-classnames",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "simple, expressive API for tailwindcss + react-native",
   "author": "Jared Henderson <jared@netrivet.com>",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,14 @@
     "react-native": "^0.63.4",
     "tailwindcss": "^2.0.2"
   },
+  "homepage": "https://github.com/jaredh159/tailwind-react-native-classnames",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredh159/tailwind-react-native-classnames.git"
+  },
+  "bugs": {
+    "url": "https://github.com/jaredh159/tailwind-react-native-classnames/issues"
+  },
   "keywords": [
     "tailwind",
     "tailwindcss",


### PR DESCRIPTION
Add `homepage`, `bug` and `repository` url in the package.json.
This add the following links in the npm page for this package, allowing the users to navigate to the repository without need a search engine.

Example of links in the npm package of a popular package:
![image](https://user-images.githubusercontent.com/1536740/118978358-9a765a00-b94d-11eb-83c6-4d46a2946f39.png)
