### PR TITLE
#35: correctly escape fractional digits in spacing config

### DIFF
--- a/src/create-styles.ts
+++ b/src/create-styles.ts
@@ -50,7 +50,7 @@ function toStyleObject(css: string): Style {
   for (const rule of stylesheet.rules) {
     if (rule.type === `rule` && `selectors` in rule) {
       for (const selector of rule.selectors || []) {
-        const utility = selector.replace(/^\./, ``).replace(`\\/`, `/`);
+        const utility = selector.replace(/^\./, ``).replace(`\\`, ``);
 
         if (isFontFamilyRule(rule)) {
           const fontFamily = fontFamilyStyle((rule as any).declarations?.[0]?.value);


### PR DESCRIPTION
With a spacing config which contains a . (e.g. p-0.5, so basically all configs), the output of trnc-create-styles is a bit "malformed":
```jsonc
{
// ...
  "p-0\\.5": {
  }
}
```

This should now be fixed.