### PR TITLE
Add CommonJS compilation target

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "2.0.6",
   "description": "simple, expressive API for tailwindcss + react-native",
   "author": "Jared Henderson <jared@netrivet.com>",
-  "main": "dist/index.js",
+  "main": "dist/cjs/index.js",
+  "module": "dist/index.js",
+  "react-native": "dist/index.js",
   "license": "MIT",
   "scripts": {
     "test": "jest",
@@ -14,7 +16,7 @@
     "ts:check": "fldev ts:check",
     "format": "fldev format",
     "format:check": "fldev format --check",
-    "compile": "fldev ts:compile",
+    "compile": "fldev ts:compile && fldev ts:compile -p tsconfig.cjs.json",
     "prepublishOnly": "npm run compile",
     "npub:precheck": "npm run lint && npm run format:check && npm run ts:check && npm run test"
   },

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "outDir": "./dist/cjs"
+  }
+}


### PR DESCRIPTION
This PR adds a new `tsconfig.cjs.json` that extends the default tsconfig, but changes compilation target to CommonJS. The CommonJS code is output to `dist/cjs` and thus doesn't interfere with the ESM code in `dist`.

For node to pick up the CJS code, I changed the `main` field in `package.json` to the CJS directory, but set both `module` and `react-native` to the ESM directory.

Note however, that this still doesn't work completely since `react-native` (which doesn't ship CommonJS code) is imported in `ClassParser.ts` and `index.ts` (through the `useDeviceContext` export). Thus, node errors when it reaches `require("react-native")`.

In my specific use case, I want to import the `create` function in a Babel Plugin to statically extract and compile the Tailwind styles.To make this work, we would need to:
1. Extract the `create` function from `index.ts` and re-export it from there (to get rid of the `export { useDeviceContext } from "./hooks"` in the same file)
2. Get rid of the `import { Platform as RnPlatform } from 'react-native'` in `ClassParser.ts`. We could achieve this by passing the Platform in the constructor for example.

Then, we would be able to `require("twrnc/create")` from a node environment and benefit from all the magic you are doing around processing styles. 🎉 

PS: Also see #87 