### PR TITLE
chore: add React to peer dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "twrnc",
       "version": "3.1.0",
       "license": "MIT",
+      "dependencies": {
+        "tailwindcss": ">=2.0.0"
+      },
       "devDependencies": {
         "@friends-library/dev": "~4.5.0",
         "@types/react": "^17.0.37",
@@ -20,6 +23,7 @@
         "ts-jest": "^27.0.5"
       },
       "peerDependencies": {
+        "react": ">=17.0.2",
         "react-native": ">=0.63.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "tailwindcss": ">=2.0.0"
   },
   "peerDependencies": {
+    "react": ">=17.0.2",
     "react-native": ">=0.63.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Adding this project to my react-native-web project keeps resulting in the error: `React is not defined`. React is currently only added to the dev dependencies, I believe it should also be added to the peerDependencies to indicate that it's required for this package to run in production.