### PR TITLE
add RN tintColor support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -403,6 +403,7 @@ to web-css, including:
 - `direction-(inherit|ltr|rtl)`
 - `align-self: baseline;` via `self-baseline`
 - `include-font-padding` and `remove-font-padding` (android only: `includeFontPadding`)
+- image tint color control (`tint-{color}` e.g. `tint-red-200`)
 
 ## JIT-Style Arbitrary Values
 

--- a/src/ClassParser.ts
+++ b/src/ClassParser.ts
@@ -219,6 +219,11 @@ export default class ClassParser {
       if (style) return style;
     }
 
+    if (this.consumePeeked(`tint-`)) {
+      style = color(`tint`, this.rest, theme?.colors);
+      if (style) return style;
+    }
+
     if (this.consumePeeked(`bg-`)) {
       style = color(`bg`, this.rest, theme?.backgroundColor);
       if (style) return style;

--- a/src/__tests__/colors.spec.ts
+++ b/src/__tests__/colors.spec.ts
@@ -50,6 +50,11 @@ describe(`colors`, () => {
 
   test(`tint colors`, () => {
     expect(tw`tint-black`).toEqual({ tintColor: `#000` });
+    expect(tw`tint-[#eaeaea]`).toEqual({ tintColor: `#eaeaea` });
+    expect(tw`tint-black/50`).toEqual({ tintColor: `rgba(0, 0, 0, 0.5)` });
+    tw = create({ theme: { colors: { foo: `#ff0000`, bar: `#00f` } } });
+    expect(tw`tint-foo`).toEqual({ tintColor: `#ff0000` });
+    expect(tw`tint-bar`).toEqual({ tintColor: `#00f` });
   });
 
   test(`rgb/a configged colors`, () => {

--- a/src/__tests__/colors.spec.ts
+++ b/src/__tests__/colors.spec.ts
@@ -48,6 +48,10 @@ describe(`colors`, () => {
     expect(tw`text-black`).toEqual({ color: `#000` });
   });
 
+  test(`tint colors`, () => {
+    expect(tw`tint-black`).toEqual({ tintColor: `#000` });
+  });
+
   test(`rgb/a configged colors`, () => {
     tw = create({
       theme: { colors: { foo: `rgb(1, 2, 3)`, bar: `rgba(4, 5, 6, 0.5)` } },

--- a/src/resolve/color.ts
+++ b/src/resolve/color.ts
@@ -107,7 +107,7 @@ const STYLE_PROPS = {
   borderLeft: { opacity: `__opacity_border`, color: `borderLeftColor` },
   borderRight: { opacity: `__opacity_border`, color: `borderRightColor` },
   shadow: { opacity: `__opacity_shadow`, color: `shadowColor` },
-  tint: { opacity: `__opacity_tint`, color: `tintColor` }
+  tint: { opacity: `__opacity_tint`, color: `tintColor` },
 };
 
 function hexToRgba(hex: string): string {

--- a/src/resolve/color.ts
+++ b/src/resolve/color.ts
@@ -107,6 +107,7 @@ const STYLE_PROPS = {
   borderLeft: { opacity: `__opacity_border`, color: `borderLeftColor` },
   borderRight: { opacity: `__opacity_border`, color: `borderRightColor` },
   shadow: { opacity: `__opacity_shadow`, color: `shadowColor` },
+  tint: { opacity: `__opacity_tint`, color: `tintColor` }
 };
 
 function hexToRgba(hex: string): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,7 +67,8 @@ export type ColorStyleType =
   | 'borderLeft'
   | 'borderRight'
   | 'borderBottom'
-  | 'shadow';
+  | 'shadow'
+  | 'tint';
 
 export type Direction =
   | 'All'

--- a/supported-utilities.md
+++ b/supported-utilities.md
@@ -101,7 +101,7 @@
 - 🚨 textShadowOffset
 - 🚨 textShadowRadius
 - ✅ textTransform
-- 🚨 tintColor
+- 😎 tintColor
 - ✅ top
 - ✅ width
 - 🚨 writingDirection


### PR DESCRIPTION
This adds RN image `tintColor` support. 
Usage : `tint-{color}`, e.g. `tint-red-200` 