### PR TITLE
Clarify how to use a custom theme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -193,6 +193,8 @@ export default tw;
 import tw from './lib/tailwind';
 ```
 
+> ⚠️ Make sure to use `module.exports = {}` instead of `export default {}` in your `tailwind.config.ts` file, as the latter is not supported.
+
 ## Enabling Device-Context Prefixes
 
 To enable prefixes that require runtime device data, like _dark mode_, and _screen size


### PR DESCRIPTION
I had the issue of having Typescript enabled (and thus `export default`) everywhere. It seems that this is not supported and we should resort to `module.exports`. After changing my code to this it is working as expected, so I wanted to update the README with this.