### PR TITLE
add border support to tw.color

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -142,6 +142,9 @@ a tailwind color. Especially useful if you're using a customized color pallette.
 
 ```js
 tw.color('blue-100');
+tw.color('bg-blue-100');
+tw.color('border-blue-100');
+tw.color('text-blue-100');
 // -> "rgba(219, 234, 254, 1)"
 ```
 

--- a/src/__tests__/tw.spec.ts
+++ b/src/__tests__/tw.spec.ts
@@ -189,6 +189,7 @@ describe(`tw`, () => {
   test(`tw.color()`, () => {
     expect(tw.color(`black`)).toBe(`#000`);
     expect(tw.color(`bg-black`)).toBe(`#000`); // incorrect usage, but still works
+    expect(tw.color(`border-black`)).toBe(`#000`); // incorrect usage, but still works
     expect(tw.color(`white/25`)).toBe(`rgba(255, 255, 255, 0.25)`);
     expect(tw.color(`black opacity-50`)).toBe(`rgba(0, 0, 0, 0.5)`);
     expect(tw.color(`red-500`)).toBe(`#ef4444`);

--- a/src/__tests__/tw.spec.ts
+++ b/src/__tests__/tw.spec.ts
@@ -190,6 +190,7 @@ describe(`tw`, () => {
     expect(tw.color(`black`)).toBe(`#000`);
     expect(tw.color(`bg-black`)).toBe(`#000`); // incorrect usage, but still works
     expect(tw.color(`border-black`)).toBe(`#000`); // incorrect usage, but still works
+    expect(tw.color(`text-black`)).toBe(`#000`); // incorrect usage, but still works
     expect(tw.color(`white/25`)).toBe(`rgba(255, 255, 255, 0.25)`);
     expect(tw.color(`black opacity-50`)).toBe(`rgba(0, 0, 0, 0.5)`);
     expect(tw.color(`red-500`)).toBe(`#ef4444`);

--- a/src/create.ts
+++ b/src/create.ts
@@ -148,7 +148,7 @@ export function create(customConfig: TwConfig, platform: Platform): TailwindFn {
     const styleObj = style(
       utils
         .split(/\s+/g)
-        .map((util) => util.replace(/^(bg|text)-/, ``))
+        .map((util) => util.replace(/^(bg|text|border)-/, ``))
         .map((util) => `bg-${util}`)
         .join(` `),
     );


### PR DESCRIPTION
Hello,

This PR adds support for `border` in `tw.color`
I also added more working examples in the readme to show all possible use-cases of `tw.color` and added a little unit test

Thank you for your work, I enjoy using this lib 😄 