### PR TITLE
feat: :sparkles: add support for arbitrary border width case and its test cases

### DIFF
--- a/src/__tests__/borders.spec.ts
+++ b/src/__tests__/borders.spec.ts
@@ -17,11 +17,26 @@ describe(`borders`, () => {
     [`border-l-2`, { borderLeftWidth: 2 }],
     [`border-white`, { borderColor: `#fff` }],
     [`border-t-white`, { borderTopColor: `#fff` }],
+    [`border-t-[#e9c46a]`, { borderTopColor: `#e9c46a` }],
     [`border-blue-200`, { borderColor: `#bfdbfe` }],
     [`border-black border-opacity-50`, { borderColor: `rgba(0, 0, 0, 0.5)` }],
     [`border-dashed`, { borderStyle: `dashed` }],
     [`border-solid`, { borderStyle: `solid` }],
     [`border-dotted`, { borderStyle: `dotted` }],
+    // Arbitrary Pixel Values
+    [`border-[25px]`, { borderWidth: 25 }],
+    [`border-t-[25px]`, { borderTopWidth: 25 }],
+    [`border-r-[25px]`, { borderRightWidth: 25 }],
+    [`border-b-[25px]`, { borderBottomWidth: 25 }],
+    [`border-l-[25px]`, { borderLeftWidth: 25 }],
+    // Arbitrary Rem Values
+    [`border-[2.5rem]`, { borderWidth: 40 }],
+    [`border-t-[2.5rem]`, { borderTopWidth: 40 }],
+    [`border-r-[2.5rem]`, { borderRightWidth: 40 }],
+    [`border-b-[2.5rem]`, { borderBottomWidth: 40 }],
+    [`border-l-[2.5rem]`, { borderLeftWidth: 40 }],
+
+    [`border-[7%]`, {}], // not supported in RN
   ];
 
   test.each(basicCases)(`tw\`%s\` -> %s`, (utility, expected) => {

--- a/src/resolve/borders.ts
+++ b/src/resolve/borders.ts
@@ -35,22 +35,23 @@ export function border(value: string, theme?: TwTheme): StyleIR | null {
       colorType = `borderRight`;
       break;
   }
-  const hasBorderColor = color(colorType, rest, theme?.borderColor);
-  if (hasBorderColor) {
-    return color(colorType, rest, theme?.borderColor);
+
+  const colorStyle = color(colorType, rest, theme?.borderColor);
+  if (colorStyle) {
+    return colorStyle;
   }
 
-  // Finally Handle Arbitrary Case
+  // Finally Handling Arbitrary Width Case
   // border-[20px] or border-[2.5rem]
   const prop = `border${direction === `All` ? `` : direction}Width`;
   rest = rest.replace(/^-/, ``);
   const numericValue = rest.slice(1, -1);
-  const arbitrary = unconfiggedStyle(prop, numericValue);
+  const arbitraryWidth = unconfiggedStyle(prop, numericValue);
   // can't use % for border-radius in RN
-  if (typeof arbitrary?.style[prop] !== `number`) {
+  if (typeof arbitraryWidth?.style[prop] !== `number`) {
     return null;
   }
-  return arbitrary;
+  return arbitraryWidth;
 }
 
 function borderWidth(

--- a/src/resolve/borders.ts
+++ b/src/resolve/borders.ts
@@ -35,8 +35,22 @@ export function border(value: string, theme?: TwTheme): StyleIR | null {
       colorType = `borderRight`;
       break;
   }
+  const hasBorderColor = color(colorType, rest, theme?.borderColor);
+  if (hasBorderColor) {
+    return color(colorType, rest, theme?.borderColor);
+  }
 
-  return color(colorType, rest, theme?.borderColor);
+  // Finally Handle Arbitrary Case
+  // border-[20px] or border-[2.5rem]
+  const prop = `border${direction === `All` ? `` : direction}Width`;
+  rest = rest.replace(/^-/, ``);
+  const numericValue = rest.slice(1, -1);
+  const arbitrary = unconfiggedStyle(prop, numericValue);
+  // can't use % for border-radius in RN
+  if (typeof arbitrary?.style[prop] !== `number`) {
+    return null;
+  }
+  return arbitrary;
 }
 
 function borderWidth(


### PR DESCRIPTION
I have added support to handle arbitrary border width. I also added cases to check it works with `rem` and `px` and not for `%`. 

Fixing #166 

I did not want to mess up with other cases, so I handled this case in the end. 

Thank you for the great library. 