### PR TITLE
Override font default styles

### DIFF
--- a/src/__tests__/custom-utils.spec.ts
+++ b/src/__tests__/custom-utils.spec.ts
@@ -42,6 +42,7 @@ describe(`custom registered utilities`, () => {
         // @ts-ignore
         tailwindPlugin(({ addUtilities }) => {
           addUtilities({
+            // @ts-ignore
             btn: { paddingTop: 33 },
             custom: `mt-1 text-white`,
           });

--- a/src/__tests__/tw.spec.ts
+++ b/src/__tests__/tw.spec.ts
@@ -261,4 +261,20 @@ describe(`tw`, () => {
     const rnViewStyle: ViewStyle = { backgroundColor: `#ff000` };
     expect(tw.style(rnViewStyle)).toEqual({ backgroundColor: `#ff000` });
   });
+
+  // @see https://github.com/jaredh159/tailwind-react-native-classnames/issues/159
+  test(`override font default styles`, () => {
+    expect(tw`font-sans`).toEqual({ fontFamily: `ui-sans-serif` });
+    expect(tw`font-bold`).toEqual({ fontWeight: `700` });
+
+    tw = create({ theme: { fontFamily: { bold: `Poppins-bold` }, fontWeight: { 'light': 600 } } });
+    expect(tw`font-sans`).toEqual({}); // Erased by override font families
+    expect(tw`font-bold`).toEqual({ fontFamily: `Poppins-bold` });
+    expect(tw`font-light`).toEqual({ fontWeight: `600` });
+
+    tw = create({ theme: { extend: { fontFamily: { bold: `Poppins-bold` }, fontWeight: { 'light': 600 } } } });
+    expect(tw`font-sans`).toEqual({ fontFamily: `ui-sans-serif` });
+    expect(tw`font-bold`).toEqual({ fontFamily: `Poppins-bold` });
+    expect(tw`font-light`).toEqual({ fontWeight: `600` });
+  });
 });

--- a/src/__tests__/tw.spec.ts
+++ b/src/__tests__/tw.spec.ts
@@ -265,7 +265,7 @@ describe(`tw`, () => {
   // @see https://github.com/jaredh159/tailwind-react-native-classnames/issues/159
   test(`override font default styles`, () => {
     expect(tw`font-sans`).toEqual({ fontFamily: `ui-sans-serif` });
-    expect(tw`font-bold`).toEqual({ fontWeight: `700` });
+    expect(tw`font-bold`).toEqual({ fontWeight: `bold` });
 
     tw = create({ theme: { fontFamily: { bold: `Poppins-bold` }, fontWeight: { 'light': 600 } } });
     expect(tw`font-sans`).toEqual({}); // Erased by override font families

--- a/src/__tests__/tw.spec.ts
+++ b/src/__tests__/tw.spec.ts
@@ -267,12 +267,18 @@ describe(`tw`, () => {
     expect(tw`font-sans`).toEqual({ fontFamily: `ui-sans-serif` });
     expect(tw`font-bold`).toEqual({ fontWeight: `bold` });
 
-    tw = create({ theme: { fontFamily: { bold: `Poppins-bold` }, fontWeight: { 'light': 600 } } });
+    tw = create({
+      theme: { fontFamily: { bold: `Poppins-bold` }, fontWeight: { light: 600 } },
+    });
     expect(tw`font-sans`).toEqual({}); // Erased by override font families
     expect(tw`font-bold`).toEqual({ fontFamily: `Poppins-bold` });
     expect(tw`font-light`).toEqual({ fontWeight: `600` });
 
-    tw = create({ theme: { extend: { fontFamily: { bold: `Poppins-bold` }, fontWeight: { 'light': 600 } } } });
+    tw = create({
+      theme: {
+        extend: { fontFamily: { bold: `Poppins-bold` }, fontWeight: { light: 600 } },
+      },
+    });
     expect(tw`font-sans`).toEqual({ fontFamily: `ui-sans-serif` });
     expect(tw`font-bold`).toEqual({ fontFamily: `Poppins-bold` });
     expect(tw`font-light`).toEqual({ fontWeight: `600` });

--- a/src/create.ts
+++ b/src/create.ts
@@ -35,6 +35,27 @@ export function create(customConfig: TwConfig, platform: Platform): TailwindFn {
     })
     .filter(([, ir]) => ir.kind !== `null`);
 
+  // Allow override default font-<name> style
+  if ( 'object' === typeof config.theme?.fontWeight) {
+    Object.entries(config.theme.fontWeight).forEach(([name, value]) => {
+      customStyleUtils.push([
+        'font-'+name,
+        complete({ fontWeight: value.toString() } as Style)
+      ]);
+    });
+  }
+
+  // Allow override default font-<name> style
+  if ( 'object' === typeof config.theme?.fontFamily) {
+    Object.entries(config.theme.fontFamily).forEach(([name, value]) => {
+      const fontFamily = Array.isArray(value) ? value[0] : value;
+      customStyleUtils.push([
+        'font-'+name,
+        complete({ fontFamily } as Style)
+      ]);
+    });
+  }
+
   function deriveCacheGroup(): string {
     return (
       [

--- a/src/create.ts
+++ b/src/create.ts
@@ -36,8 +36,11 @@ export function create(customConfig: TwConfig, platform: Platform): TailwindFn {
     .filter(([, ir]) => ir.kind !== `null`);
 
   // Allow override default font-<name> style
-  if ( 'object' === typeof config.theme?.fontWeight) {
-    Object.entries(config.theme.fontWeight).forEach(([name, value]) => {
+  if (customConfig.theme?.fontWeight || customConfig.theme?.extend?.fontWeight) {
+    [
+      ...Object.entries(customConfig.theme?.fontWeight ?? {}),
+      ...Object.entries(customConfig.theme?.extend?.fontWeight ?? {})
+    ].forEach(([name, value]) => {
       customStyleUtils.push([
         'font-'+name,
         complete({ fontWeight: value.toString() } as Style)
@@ -47,7 +50,10 @@ export function create(customConfig: TwConfig, platform: Platform): TailwindFn {
 
   // Allow override default font-<name> style
   if ( 'object' === typeof config.theme?.fontFamily) {
-    Object.entries(config.theme.fontFamily).forEach(([name, value]) => {
+    [
+      ...Object.entries(customConfig.theme?.fontFamily ?? {}),
+      ...Object.entries(customConfig.theme?.extend?.fontFamily ?? {})
+    ].forEach(([name, value]) => {
       const fontFamily = Array.isArray(value) ? value[0] : value;
       customStyleUtils.push([
         'font-'+name,

--- a/src/create.ts
+++ b/src/create.ts
@@ -39,26 +39,23 @@ export function create(customConfig: TwConfig, platform: Platform): TailwindFn {
   if (customConfig.theme?.fontWeight || customConfig.theme?.extend?.fontWeight) {
     [
       ...Object.entries(customConfig.theme?.fontWeight ?? {}),
-      ...Object.entries(customConfig.theme?.extend?.fontWeight ?? {})
+      ...Object.entries(customConfig.theme?.extend?.fontWeight ?? {}),
     ].forEach(([name, value]) => {
       customStyleUtils.push([
-        'font-'+name,
-        complete({ fontWeight: value.toString() } as Style)
+        `font-` + name,
+        complete({ fontWeight: value.toString() } as Style),
       ]);
     });
   }
 
   // Allow override default font-<name> style
-  if ( 'object' === typeof config.theme?.fontFamily) {
+  if (`object` === typeof config.theme?.fontFamily) {
     [
       ...Object.entries(customConfig.theme?.fontFamily ?? {}),
-      ...Object.entries(customConfig.theme?.extend?.fontFamily ?? {})
+      ...Object.entries(customConfig.theme?.extend?.fontFamily ?? {}),
     ].forEach(([name, value]) => {
       const fontFamily = Array.isArray(value) ? value[0] : value;
-      customStyleUtils.push([
-        'font-'+name,
-        complete({ fontFamily } as Style)
-      ]);
+      customStyleUtils.push([`font-` + name, complete({ fontFamily } as Style)]);
     });
   }
 


### PR DESCRIPTION
Hi @jaredh159,

This PR solves issue #159 that I opened a few months ago.

After thinking about it, the only default styles (cf: defaultStyles in styles.ts) that should be overloadable are the font-<name>.

So this PR allows this, without breaking change.

Looking forward to your return,