### PR TITLE
fix ordering when using ir cache

### DIFF
--- a/src/ClassParser.ts
+++ b/src/ClassParser.ts
@@ -118,6 +118,9 @@ export default class ClassParser {
     // resolve things like ios:hidden, after prefix removed
     const cached = this.cache.getIr(this.rest);
     if (cached) {
+      if (this.order !== undefined) {
+        return { kind: `ordered`, order: this.order, styleIr: cached };
+      }
       return cached;
     }
 

--- a/src/__tests__/ir-caching-breakpoints.spec.ts
+++ b/src/__tests__/ir-caching-breakpoints.spec.ts
@@ -1,0 +1,24 @@
+import { create } from "..";
+
+describe(`ir caching between breakpoints`, () => {
+  let tw = create();
+
+  const cases: Array<
+    [
+      dims: { width: number; height: number } | null,
+      utility: string,
+      expected: Record<string, string | number>
+    ]
+  > = [
+    [{ width: 1100, height: 600 }, `w-3`, { width: 12 }],
+    [{ width: 1100, height: 600 }, `w-1 lg:w-3`, { width: 12 }],
+    [{ width: 1100, height: 600 }, `w-1 md:w-2 lg:w-3`, { width: 12 }],
+  ];
+
+  test.each(cases)(`tw\`%s\` -> %s`, (dims, utility, expected) => {
+    if (dims) {
+      tw.setWindowDimensions(dims);
+    }
+    expect(tw.style(utility)).toEqual(expected);
+  });
+});

--- a/src/__tests__/ir-caching-breakpoints.spec.ts
+++ b/src/__tests__/ir-caching-breakpoints.spec.ts
@@ -1,13 +1,13 @@
-import { create } from "..";
+import { create } from '..';
 
 describe(`ir caching between breakpoints`, () => {
-  let tw = create();
+  const tw = create();
 
   const cases: Array<
     [
       dims: { width: number; height: number } | null,
       utility: string,
-      expected: Record<string, string | number>
+      expected: Record<string, string | number>,
     ]
   > = [
     [{ width: 1100, height: 600 }, `w-3`, { width: 12 }],


### PR DESCRIPTION
In an expo application with expo-router, breakpoints on RN web would not work correctly if the window was resized before a navigation event.

the issue was down to the ordering of breakpoints essentially being removed when a utility was cached individually.
