### PR TITLE
Add types to exports map

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,12 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./dist/esm/index.d.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     },
     "./create": {
+      "types": "./dist/esm/create.d.ts",
       "import": "./dist/esm/create.js",
       "require": "./dist/cjs/create.js"
     }


### PR DESCRIPTION
Hi. I'm using `twrnc` in a project that uses Typescript 5.3 and `moduleResolution: "NodeNext"`. With this combination, Typescript is unable to locate type declarations for `twrnc` as it looks specifically at the `exports` map in `package.json`. Currently, that `exports` map doesn't list `types` but when those entries are added Typescript can load the declarations successfully. 