### PR TITLE
fix useAppColorScheme hook to return correct scheme

### DIFF
--- a/src/create.ts
+++ b/src/create.ts
@@ -204,6 +204,10 @@ export function create(customConfig: TwConfig, platform: Platform): TailwindFn {
     configureCache();
   };
 
+  tailwindFn.getColorScheme = () => {
+    return device.colorScheme;
+  };
+
   return tailwindFn;
 }
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useColorScheme, useWindowDimensions, Appearance } from 'react-native';
+import { useColorScheme, useWindowDimensions } from 'react-native';
 import type { TailwindFn, RnColorScheme } from './types';
 
 type Options = {
@@ -29,7 +29,7 @@ export function useAppColorScheme(
   setColorScheme: (colorScheme: RnColorScheme) => void,
 ] {
   const [colorScheme, setColorScheme] = useState<RnColorScheme>(
-    initialValue ?? Appearance.getColorScheme(),
+    initialValue ?? tw.getColorScheme(),
   );
   return [
     colorScheme,

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ export interface TailwindFn {
   setFontScale: (fontScale: number) => unknown;
   setPixelDensity: (pixelDensity: 1 | 2) => unknown;
   setColorScheme: (colorScheme: RnColorScheme) => unknown;
+  getColorScheme: () => RnColorScheme;
 }
 
 export type ClassInput =


### PR DESCRIPTION
When a device is in dark mode and you set withDeviceColorScheme to false, the application renders in light mode as expected.

However, in contrast to what is rendered, the `useAppColorScheme` hook incorrectly indicates that the application is in dark mode.

```tsx
  useDeviceContext(tw, {
    withDeviceColorScheme: false,
  });

  const [colorScheme, toggleColorScheme, setColorScheme] = useAppColorScheme(tw);
  // colorScheme is 'dark'. It should be 'light'.
```

Unless I'm mistaken, it looked like `useAppColorScheme` was completely decoupled from twrnc's colour scheme. I'm not sure if this was intentional for any reason? If not, does `useAppColorScheme`'s `initialValue?: RnColorScheme` actually have a use case?

