### PR TITLE
Configure tailwind config

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -180,6 +180,17 @@ You can use `twrnc` right out of the box if you haven't customized your
 tailwind customizations you'd like to use. For that reason, we expose the ability to
 create a **custom configured version** of the `tw` function object.
 
+### Initialize
+
+```js
+// main.js (When the program will be initialized)
+import { configure } from 'twrnc';
+
+configure(require(`./tailwind.config.js`));
+```
+
+### Create your own tw function
+
 ```js
 // lib/tailwind.js
 import { create } from 'twrnc';

--- a/src/configure.ts
+++ b/src/configure.ts
@@ -1,0 +1,11 @@
+import type { TwConfig } from './tw-config';
+
+let initialTwConfig: TwConfig | undefined;
+
+export function getInitialTwConfig(): TwConfig | undefined {
+  return initialTwConfig;
+}
+
+export function configure(twConfig: TwConfig): void {
+  initialTwConfig = twConfig;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,9 +3,17 @@ import type { TailwindFn, RnColorScheme, ClassInput, Style } from './types';
 import type { TwConfig } from './tw-config';
 import plugin from './plugin';
 import rawCreate from './create';
+import { getInitialTwConfig } from './configure';
 
-// Apply default config and inject RN Platform
-const create = (twConfig: TwConfig = {}): TailwindFn => rawCreate(twConfig, Platform.OS);
+const initialTwConfig = getInitialTwConfig();
+
+/**
+ * Apply default config and inject RN Platform
+ * If no config is provided, use the initial config
+ */
+const create = (twConfig: TwConfig = initialTwConfig || {}): TailwindFn => {
+  return rawCreate(twConfig, Platform.OS);
+};
 
 export type { TailwindFn, TwConfig, RnColorScheme, ClassInput, Style };
 export { useDeviceContext, useAppColorScheme } from './hooks';


### PR DESCRIPTION
Hello, thank you for your outstanding results.

The way to create and manage a separate file is to write down a long relative path or put aliases to import the file, which is not a very good developer experience.

This provides a way to initialize the tailwind config without creating a separate file (libs/tailwind.js).
As a result, developers can import 'twnrc' through a single line of configuration and use it immediately.