### PR TITLE
Add sx utility function

### DIFF
--- a/src/__tests__/tw.spec.ts
+++ b/src/__tests__/tw.spec.ts
@@ -3,6 +3,7 @@ import { describe, test, expect } from '@jest/globals';
 import type { ViewStyle } from 'react-native';
 import type { TwConfig } from '../tw-config';
 import { create } from '../';
+import lineHeight from '../resolve/line-height';
 
 jest.mock(`react-native`, () => ({
   Platform: { OS: `ios` },
@@ -327,5 +328,20 @@ describe(`tw`, () => {
     expect(tw.style(`w-3`)).toEqual({ width: 12 });
     expect(tw.style(`w-1 lg:w-3`)).toEqual({ width: 12 });
     expect(tw.style(`w-1 md:w-2 lg:w-3`)).toEqual({ width: 12 });
+  });
+
+  test(`Returns a merged style that can be used in React Native by combining two styles`, () => {
+    const tw = create();
+    expect(tw.sx(`text-xs font-bold`, tw`leading-[14px] font-medium`)).toEqual({
+      fontSize: 12,
+      lineHeight: 14,
+      fontWeight: `500`,
+    });
+    // more case
+    expect(tw.sx(`text-xs font-bold`, { fontSize: 16, lineHeight: 14 })).toEqual({
+      fontSize: 16,
+      lineHeight: 14,
+      fontWeight: `bold`,
+    });
   });
 });

--- a/src/create.ts
+++ b/src/create.ts
@@ -1,4 +1,5 @@
 import resolveConfig from 'tailwindcss/resolveConfig';
+import type { StyleProp } from 'react-native';
 import type {
   ClassInput,
   DependentStyle,
@@ -157,6 +158,20 @@ export function create(customConfig: TwConfig, platform: Platform): TailwindFn {
     return resolved;
   }
 
+  /**
+   * Returns a merged style that can be used in React Native by combining two styles.
+   *
+   * @param twStyle The style returned by TailwindFn.
+   * @param style The style used in React Native.
+   */
+  function sx<T>(classes: ClassInput, style: StyleProp<T>): Style | StyleProp<T> {
+    const tailwindStyle = tailwindFn.style(classes);
+
+    if (!style || typeof style !== `object`) return tailwindStyle;
+
+    return { ...tailwindStyle, ...style };
+  }
+
   function color(utils: string): string | undefined {
     const styleObj = style(
       utils
@@ -171,6 +186,7 @@ export function create(customConfig: TwConfig, platform: Platform): TailwindFn {
   }
 
   tailwindFn.style = style;
+  tailwindFn.sx = sx;
   tailwindFn.color = color;
 
   tailwindFn.prefixMatch = (...prefixes: string[]) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export { useDeviceContext, useAppColorScheme } from './hooks';
 
 const tailwind = create();
 const style = tailwind.style;
+const sx = tailwind.sx;
 
 export default tailwind;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,9 @@
-import type { ViewStyle, TextStyle, ImageStyle } from 'react-native';
+import type { ViewStyle, TextStyle, ImageStyle, StyleProp } from 'react-native';
 
 export interface TailwindFn {
   (strings: TemplateStringsArray, ...values: (string | number)[]): Style;
   style: (...inputs: ClassInput[]) => Style;
+  sx<T>(classes: ClassInput, style: StyleProp<T>): Style | StyleProp<T>;
   color: (color: string) => string | undefined;
   prefixMatch: (...prefixes: string[]) => boolean;
   memoBuster: string;


### PR DESCRIPTION
<img width="907" alt="iShot_2024-02-24_17 15 04" src="https://github.com/jaredh159/tailwind-react-native-classnames/assets/22005861/b50fd4e2-e8e8-4c7f-a2a8-cbce44707ade">

This is a utility that proves to be useful when wanting to merge internal and external styles within a component. I've been actively using the `sx` function in my current project, finding it immensely helpful. Hence, I thought it would be a beneficial addition to `twnrc`.

Currently, we need to receive `className` as a string and pass it as an argument to `tw.style`. However, this approach requires developers to manually add the `className` prop, which can be cumbersome.

`sx`, on the other hand, mitigates this effort by accepting RN's `StyleProp` as the second parameter, simplifying the process of passing styles.
