### PR TITLE
Fix duplicated style priority

### DIFF
--- a/src/__tests__/tw.spec.ts
+++ b/src/__tests__/tw.spec.ts
@@ -328,4 +328,9 @@ describe(`tw`, () => {
     expect(tw.style(`w-1 lg:w-3`)).toEqual({ width: 12 });
     expect(tw.style(`w-1 md:w-2 lg:w-3`)).toEqual({ width: 12 });
   });
+
+  test(`duplicated style priority`, () => {
+    expect(tw`bg-white bg-black`).toEqual({ backgroundColor: `#000` });
+    expect(tw`bg-white bg-black bg-white`).toEqual({ backgroundColor: `#fff` });
+  });
 });

--- a/src/parse-inputs.ts
+++ b/src/parse-inputs.ts
@@ -32,5 +32,5 @@ function split(str: string): string[] {
 }
 
 function unique(className: string, index: number, classes: string[]): boolean {
-  return classes.indexOf(className) === index;
+  return classes.lastIndexOf(className) === index;
 }


### PR DESCRIPTION
fix #245 

The `indexOf` method returns the index of the first occurrence of the searched element, effectively removing duplicated classes that appear later. Modify it to use `lastIndexOf` instead, so that the earlier duplicated class gets removed, prioritizing the class appearing later.