### PR TITLE
fix: support fontWeight attribute in fontSize token

### DIFF
--- a/src/__tests__/font-size.spec.ts
+++ b/src/__tests__/font-size.spec.ts
@@ -65,6 +65,9 @@ describe(`font size`, () => {
     tw = create({ theme: { fontSize: { xs: [`0.75rem`, { letterSpacing: `1px` }] } } });
     expect(tw`text-xs`).toEqual({ fontSize: 12, letterSpacing: 1 });
 
+    tw = create({ theme: { fontSize: { xs: [`0.75rem`, { fontWeight: `700` }] } } });
+    expect(tw`text-xs`).toEqual({ fontSize: 12, fontWeight: 700 });
+
     tw = create({
       theme: {
         fontSize: { xs: [`0.75rem`, { lineHeight: `0.5rem`, letterSpacing: `1px` }] },

--- a/src/resolve/font-size.ts
+++ b/src/resolve/font-size.ts
@@ -50,13 +50,17 @@ export default function fontSize(
     );
   }
 
-  const { lineHeight, letterSpacing } = otherProps;
+  const { lineHeight, letterSpacing, fontWeight } = otherProps;
   if (lineHeight) {
     mergeStyle(`lineHeight`, calculateLineHeight(lineHeight, style), style);
   }
 
   if (letterSpacing) {
     mergeStyle(`letterSpacing`, letterSpacing, style);
+  }
+
+  if (fontWeight) {
+    mergeStyle(`fontWeight`, fontWeight, style);
   }
 
   return complete(style);

--- a/src/tw-config.ts
+++ b/src/tw-config.ts
@@ -3,7 +3,7 @@ import type { PluginFunction } from './types';
 type TwFontSize =
   | string
   | [string, string]
-  | [string, { lineHeight?: string; letterSpacing?: string }];
+  | [string, { lineHeight?: string; letterSpacing?: string; fontWeight?: string }];
 
 type TwScreen = string | { max?: string; min?: string };
 


### PR DESCRIPTION
Hello,

I've been using this library extensively, and it's been incredibly helpful.

While adding custom configurations to tailwind.config.js, I noticed an attribute that wasn't being applied to fontSize. I've added this attribute to address the issue.

Please take a moment to review my changes. If there's anything missing or needing improvement, please let me know. I hope this PR can be merged.

Reference: [Tailwind CSS Font Size Documentation](https://tailwindcss.com/docs/font-size#providing-a-default-line-height)